### PR TITLE
Bump `email-builder-core` to latest 2.1.2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "bluebird": "^3.4.1",
-    "email-builder-core": "^2.0.0"
+    "email-builder-core": "^2.1.2"
   }
 }


### PR DESCRIPTION
Resolves https://github.com/Email-builder/email-builder-core/pull/19 fully.